### PR TITLE
feat: enhance statusline with session cost, turn duration, and version display

### DIFF
--- a/hooks/PreToolUse/validate_task_graph_compliance.py
+++ b/hooks/PreToolUse/validate_task_graph_compliance.py
@@ -30,21 +30,21 @@ def main() -> int:
 
     # Check 1: Detect oversized input
     if stdin_size >= MAX_STDIN_SIZE:
-        print(f"ERROR: stdin JSON exceeds maximum size (1MB)", file=sys.stderr)
-        print(f"Received: {stdin_size} bytes", file=sys.stderr)
+        sys.stderr.write("ERROR: stdin JSON exceeds maximum size (1MB)\n")
+        sys.stderr.write(f"Received: {stdin_size} bytes\n")
         return 1
 
     # Check 2: Detect empty input
     if not stdin_json:
-        print("ERROR: stdin is empty, expected JSON input from PreToolUse hook", file=sys.stderr)
+        sys.stderr.write("ERROR: stdin is empty, expected JSON input from PreToolUse hook\n")
         return 1
 
     # Check 3: Validate JSON syntax
     try:
         tool_input = json.loads(stdin_json)
     except json.JSONDecodeError:
-        print("ERROR: stdin is not valid JSON", file=sys.stderr)
-        print(f"Received first 200 chars: {stdin_json[:200]}", file=sys.stderr)
+        sys.stderr.write("ERROR: stdin is not valid JSON\n")
+        sys.stderr.write(f"Received first 200 chars: {stdin_json[:200]}\n")
         return 1
 
     # Get tool name from input or first argument
@@ -83,26 +83,26 @@ def main() -> int:
     try:
         task_graph = json.loads(task_graph_file.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
-        print(f"WARNING: Failed to read task graph: {e}", file=sys.stderr)
+        sys.stderr.write(f"WARNING: Failed to read task graph: {e}\n")
         return 0  # Allow if we can't read the task graph
 
     # If task graph exists but no phase ID in prompt, this is a compliance violation
     if not phase_id:
-        print("❌ TASK GRAPH COMPLIANCE VIOLATION", file=sys.stderr)
-        print("", file=sys.stderr)
-        print(f"An active task graph exists at: {task_graph_file}", file=sys.stderr)
-        print("But this Task invocation is missing a Phase ID marker.", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("REQUIRED: Include 'Phase ID: phase_X_Y' at the start of your Task prompt.", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("Example:", file=sys.stderr)
-        print("  Phase ID: phase_0_0", file=sys.stderr)
-        print("  Agent: codebase-context-analyzer", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("  [Your task description...]", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("If you believe this task graph is outdated, delete it first:", file=sys.stderr)
-        print(f"  rm {task_graph_file}", file=sys.stderr)
+        sys.stderr.write("❌ TASK GRAPH COMPLIANCE VIOLATION\n")
+        sys.stderr.write("\n")
+        sys.stderr.write(f"An active task graph exists at: {task_graph_file}\n")
+        sys.stderr.write("But this Task invocation is missing a Phase ID marker.\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("REQUIRED: Include 'Phase ID: phase_X_Y' at the start of your Task prompt.\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("Example:\n")
+        sys.stderr.write("  Phase ID: phase_0_0\n")
+        sys.stderr.write("  Agent: codebase-context-analyzer\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("  [Your task description...]\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("If you believe this task graph is outdated, delete it first:\n")
+        sys.stderr.write(f"  rm {task_graph_file}\n")
         return 1
 
     # Validate phase ID exists in task graph
@@ -118,17 +118,17 @@ def main() -> int:
             break
 
     if not phase_exists:
-        print(f"❌ INVALID PHASE ID: {phase_id}", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("This phase ID does not exist in the active task graph.", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("Available phases:", file=sys.stderr)
+        sys.stderr.write(f"❌ INVALID PHASE ID: {phase_id}\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("This phase ID does not exist in the active task graph.\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("Available phases:\n")
         for wave in task_graph.get("waves", []):
             for phase in wave.get("phases", []):
-                print(f"  - {phase.get('phase_id')}", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("Check your execution plan or clear the task graph:", file=sys.stderr)
-        print(f"  rm {task_graph_file}", file=sys.stderr)
+                sys.stderr.write(f"  - {phase.get('phase_id')}\n")
+        sys.stderr.write("\n")
+        sys.stderr.write("Check your execution plan or clear the task graph:\n")
+        sys.stderr.write(f"  rm {task_graph_file}\n")
         return 1
 
     # Get current wave from task graph
@@ -136,13 +136,13 @@ def main() -> int:
 
     # Validate wave order
     if phase_wave is not None and phase_wave > current_wave:
-        print("❌ WAVE ORDER VIOLATION", file=sys.stderr)
-        print("", file=sys.stderr)
-        print(f"Current wave: {current_wave}", file=sys.stderr)
-        print(f"Attempted phase: {phase_id} (wave {phase_wave})", file=sys.stderr)
-        print("", file=sys.stderr)
-        print(f"Cannot start Wave {phase_wave} tasks while Wave {current_wave} is incomplete.", file=sys.stderr)
-        print(f"Complete all Wave {current_wave} phases first.", file=sys.stderr)
+        sys.stderr.write("❌ WAVE ORDER VIOLATION\n")
+        sys.stderr.write("\n")
+        sys.stderr.write(f"Current wave: {current_wave}\n")
+        sys.stderr.write(f"Attempted phase: {phase_id} (wave {phase_wave})\n")
+        sys.stderr.write("\n")
+        sys.stderr.write(f"Cannot start Wave {phase_wave} tasks while Wave {current_wave} is incomplete.\n")
+        sys.stderr.write(f"Complete all Wave {current_wave} phases first.\n")
         return 1
 
     # Validation passed


### PR DESCRIPTION
### **User description**
## Summary

- **Session cost tracking** - Shows project-specific daily cost vs total daily cost using ccusage
- **Claude version display** - Version shown first in row 1 (e.g., "v2.1.25")  
- **Turn duration with sparkline** - Tracks last 10 turns, coral-colored sparkline visualization
- **Cost display format** - New format: `💰 $97.15 (🎯 $14.64)` (total daily | project session)
- **CWD color fix** - Changed to cyan for visibility on both light and dark themes
- **60-second cost caching** - Reduces statusline refresh latency from ~27s to ~1s
- **Windows compatibility** - All features work on Windows (tempfile.gettempdir(), pathlib, UTF-8)

## Layout Changes

**Row 1:** Version | Model | Style | Costs | Context  
**Row 2:** Turn duration + sparkline | Git branch | CWD

## Technical Details

### Cost Caching
- Caches ccusage results for 60 seconds in temp file
- Cache invalidated on directory change
- Dramatically improves statusline responsiveness

### Turn Duration Tracking
- UserPromptSubmit hook records turn start timestamp
- Stop hook calculates and records turn duration
- History of last 10 turns stored for sparkline generation
- Coral-colored sparkline using RGB true color codes

### Code Quality
- Replace `print()` with `sys.stderr.write()` in hooks for proper error output
- Add noqa comments for subprocess security warnings (trusted inputs)
- Formatting fixes for ruff compliance

## Test plan

- [ ] Verify statusline displays correctly on dark theme terminals
- [ ] Verify statusline displays correctly on light theme terminals
- [ ] Verify cost caching reduces refresh latency
- [ ] Verify turn duration appears after first completed turn
- [ ] Verify sparkline updates with each turn
- [ ] Test on Windows (if available)

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add session cost tracking with project-specific daily cost display

- Implement turn duration tracking with coral sparkline visualization

- Display Claude version in statusline (e.g., "v2.1.25")

- Add 60-second cost caching to reduce statusline refresh latency from ~27s to ~1s

- Change CWD color to cyan for visibility on both light and dark themes

- Replace print() with sys.stderr.write() in hooks for proper error output

- Ensure Windows compatibility using tempfile.gettempdir() and pathlib


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UserPromptSubmit Hook"] -->|"Record turn start timestamp"| B["State File"]
  C["Stop Hook"] -->|"Calculate duration from timestamp"| D["Duration File"]
  D -->|"Read last_turn_duration.txt"| E["Statusline Script"]
  F["ccusage Command"] -->|"Fetch costs"| G["Cost Cache"]
  G -->|"Cache valid 60s"| E
  E -->|"Display version, costs, duration, sparkline"| H["Enhanced Statusline"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>validate_task_graph_compliance.py</strong><dd><code>Replace print with sys.stderr.write for error output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hooks/PreToolUse/validate_task_graph_compliance.py

<ul><li>Replace all print() calls with sys.stderr.write() for proper error <br>output<br> <li> Add newline characters explicitly in sys.stderr.write() calls<br> <li> Maintain consistent error message formatting across validation checks</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/claude-code-workflow-orchestration/pull/26/files#diff-cb78e95e4d5675db8f4a4f6e11820cfab131476f0751b9d12a263d2c393b6042">+37/-37</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clear-delegation-sessions.py</strong><dd><code>Add turn start timestamp recording for duration tracking</code>&nbsp; </dd></summary>
<hr>

hooks/UserPromptSubmit/clear-delegation-sessions.py

<ul><li>Add new function record_turn_start_timestamp() to record when user <br>prompt is submitted<br> <li> Write timestamp to turn_start_timestamp.txt file in state directory<br> <li> Call record_turn_start_timestamp() in main() before any bypass checks<br> <li> Enable turn duration calculation by stop hook</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/claude-code-workflow-orchestration/pull/26/files#diff-938804f6391e1f4bdf46da7ee4a74ab2ccf0854ad94789dc5875c4c90f54ba8d">+18/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>python_stop_hook.py</strong><dd><code>Add turn duration tracking with history for sparkline</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

hooks/stop/python_stop_hook.py

<ul><li>Add tempfile import for cross-platform temp directory handling<br> <li> Implement format_duration() function to convert seconds to <br>human-readable format (e.g., "45s", "1m 23s")<br> <li> Implement append_duration_to_history() to maintain last 10 turn <br>durations in JSON file<br> <li> Implement calculate_and_record_turn_duration() to read start timestamp <br>and record formatted duration<br> <li> Call calculate_and_record_turn_duration() at start of main() before <br>workflow continuation check<br> <li> Replace hardcoded /tmp paths with tempfile.gettempdir() for Windows <br>compatibility<br> <li> Add noqa comments (S603, T201) for subprocess and print security <br>warnings<br> <li> Fix formatting issues for ruff compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/claude-code-workflow-orchestration/pull/26/files#diff-a1b7f423f60d058a6918d284c33be00161b5fc6d2675ecc95b57d5569df4e01e">+145/-24</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>statusline.py</strong><dd><code>Add cost caching, version display, and turn duration sparkline</code></dd></summary>
<hr>

scripts/statusline.py

<ul><li>Add cost caching mechanism with 60-second TTL to reduce latency from <br>~27s to ~1s<br> <li> Implement load_cost_cache(), save_cost_cache(), is_cache_valid() for <br>cache management<br> <li> Split cost fetching into fetch_daily_cost_raw() and <br>fetch_session_cost_raw() functions<br> <li> Add get_costs_cached() to return cached or fresh costs based on TTL <br>and directory<br> <li> Implement get_claude_version() to retrieve Claude Code version from <br>CLI<br> <li> Implement generate_sparkline() to create coral-colored sparkline from <br>duration history<br> <li> Implement get_duration_history() to read turn durations from state <br>file<br> <li> Implement get_turn_duration() to format duration with sparkline <br>visualization<br> <li> Change CWD color from WHITE to SHINY_AQUA (cyan) for visibility on <br>both light/dark themes<br> <li> Update statusline layout to Row 1: Version | Model | Style | Costs | <br>Context and Row 2: Duration+Sparkline | Git | CWD<br> <li> Replace hardcoded /tmp paths with tempfile.gettempdir() for <br>cross-platform compatibility<br> <li> Use sys.stdout.write() instead of print() for statusline output<br> <li> Add noqa comments (S603, S607) for subprocess security warnings<br> <li> Format cost display as "💰 $Y.YY (🎯 $X.XX)" showing daily cost and <br>session cost</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/claude-code-workflow-orchestration/pull/26/files#diff-55c4d48448998a482a1991c703b6853e86c6a8b733660ed0af5489d8203988e5">+354/-31</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

