### PR TITLE
fix: break delegate→plan-mode→approve infinite loop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "workflow-orchestrator",
       "source": "./",
       "description": "Delegation system with workflow orchestration, specialized agents, and parallel execution for Claude Code",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": {
         "name": "Nadav Barkai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-orchestrator",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Delegation system with workflow orchestration, specialized agents, and parallel execution for Claude Code",
   "author": {
     "name": "Nadav Barkai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.1] - 2026-04-12
+
+### Fixed
+
+- **Fix infinite delegate→plan-mode→approve loop.** After `ExitPlanMode`, the Stop hook's continuation signal was too vague (`reason: "continue"`), causing the model to re-route through `/workflow-orchestrator:delegate` and re-enter plan mode indefinitely. Three-layer fix: (1) Stop hook now emits explicit anti-redelegation directive in `reason` field, (2) orchestrator stub exception for continuation after plan approval, (3) delegate skill RE-INVOCATION GUARD at entry point.
+- **Narrow continuation guard triggers** (Qodo review feedback). Layer 2 and Layer 3 guards now trigger only on the deterministic Stop-hook continuation marker, not the broader "most recent tool call was ExitPlanMode" heuristic. Explicit tool whitelist added for the exception path.
+
 ## [2.0.0] - 2026-04-08
 
 Re-tag of `1.18.0` as a major release to honor semver. The same code, tagged honestly.

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -4,6 +4,10 @@ argument-hint: [task description]
 allowed-tools: Agent, Task, EnterPlanMode, ExitPlanMode, AskUserQuestion, TaskCreate, TaskUpdate, TaskGet, TaskList, ToolSearch, TeamCreate, SendMessage
 ---
 
+## RE-INVOCATION GUARD (READ FIRST)
+
+Before doing ANYTHING else: if your most recent tool call in this conversation was `ExitPlanMode`, OR if you arrived here via a "PLAN ALREADY APPROVED" / "continuing to STAGE 1" continuation message, the plan is already approved. **Do NOT call `EnterPlanMode`. Do NOT re-enter Stage 0.** Skip directly to **STAGE 1: EXECUTION** — render the dependency graph from the approved plan in context and begin spawning Wave 0 agents. Re-entering plan mode here causes an infinite delegate→plan→approve loop.
+
 # Workflow Orchestrator System Prompt
 
 ## Purpose

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -6,7 +6,7 @@ allowed-tools: Agent, Task, EnterPlanMode, ExitPlanMode, AskUserQuestion, TaskCr
 
 ## RE-INVOCATION GUARD (READ FIRST)
 
-Before doing ANYTHING else: if your most recent tool call in this conversation was `ExitPlanMode`, OR if you arrived here via a "PLAN ALREADY APPROVED" / "continuing to STAGE 1" continuation message, the plan is already approved. **Do NOT call `EnterPlanMode`. Do NOT re-enter Stage 0.** Skip directly to **STAGE 1: EXECUTION** — render the dependency graph from the approved plan in context and begin spawning Wave 0 agents. Re-entering plan mode here causes an infinite delegate→plan→approve loop.
+Before doing ANYTHING else: if you arrived here via a "PLAN ALREADY APPROVED" or "continuing to STAGE 1" continuation message from the Stop hook, the plan is already approved. **Do NOT call `EnterPlanMode`. Do NOT re-enter Stage 0.** Skip directly to **STAGE 1: EXECUTION** — render the dependency graph from the approved plan in context and begin spawning Wave 0 agents. In this path, the `Agent` tool (plus `TaskCreate`/`TaskUpdate`/`TaskGet`, and `TeamCreate`/`SendMessage` in team mode) is permitted for spawning Wave 0 phases. Re-entering plan mode here causes an infinite delegate→plan→approve loop.
 
 # Workflow Orchestrator System Prompt
 

--- a/hooks/stop/python_stop_hook.py
+++ b/hooks/stop/python_stop_hook.py
@@ -173,8 +173,13 @@ def check_workflow_continuation() -> bool:
         # This mimics ralph-wiggum's loop mechanism
         output = {
             "decision": "block",
-            "reason": "continue",
-            "systemMessage": "⚡ Workflow continuation: Proceeding to STAGE 1 execution.",
+            "reason": (
+                "PLAN ALREADY APPROVED. Execute Stage 1 NOW directly from the existing "
+                "approved plan in context. DO NOT call /workflow-orchestrator:delegate. "
+                "DO NOT call EnterPlanMode. DO NOT re-enter plan mode. "
+                "Render the dependency graph and start spawning Wave 0 agents."
+            ),
+            "systemMessage": "⚡ Continuing to STAGE 1 execution (plan already approved).",
         }
         print(json.dumps(output))  # noqa: T201
         logger.debug("Output block decision with 'continue' reason")

--- a/system-prompts/orchestrator_stub.md
+++ b/system-prompts/orchestrator_stub.md
@@ -10,6 +10,10 @@ Any user request that requires work — writing code, running tools, multi-step 
 
 The main agent does not execute work tools directly. Use only: Tasks API, AskUserQuestion, and `/workflow-orchestrator:delegate`. The delegate command loads the full orchestrator (planning, agent assignment, execution waves) on demand.
 
+## Exception — continuation after plan approval
+
+If your most recent tool call was `ExitPlanMode`, OR you received a "PLAN ALREADY APPROVED" / "continuing to STAGE 1" continuation message, **do NOT re-invoke `/workflow-orchestrator:delegate`** and **do NOT call `EnterPlanMode`** again. The orchestrator is already loaded and the plan is already approved — proceed directly to Stage 1 execution by rendering the dependency graph and spawning Wave 0 agents. The "all work → delegate" rule above does NOT apply during in-flight delegation.
+
 ## Team Mode
 
 If `TeamCreate` is in your available tools, agent teams are enabled. When you run `/workflow-orchestrator:delegate`, default to team mode (`TeamCreate` + `Agent(team_name=...)`) for multi-agent work. If `TeamCreate` is not available, the delegate flow falls back to parallel subagents automatically.

--- a/system-prompts/orchestrator_stub.md
+++ b/system-prompts/orchestrator_stub.md
@@ -12,7 +12,7 @@ The main agent does not execute work tools directly. Use only: Tasks API, AskUse
 
 ## Exception — continuation after plan approval
 
-If your most recent tool call was `ExitPlanMode`, OR you received a "PLAN ALREADY APPROVED" / "continuing to STAGE 1" continuation message, **do NOT re-invoke `/workflow-orchestrator:delegate`** and **do NOT call `EnterPlanMode`** again. The orchestrator is already loaded and the plan is already approved — proceed directly to Stage 1 execution by rendering the dependency graph and spawning Wave 0 agents. The "all work → delegate" rule above does NOT apply during in-flight delegation.
+If you received a "PLAN ALREADY APPROVED" or "continuing to STAGE 1" continuation message from the Stop hook, **do NOT re-invoke `/workflow-orchestrator:delegate`** and **do NOT call `EnterPlanMode`** again. The orchestrator is already loaded and the plan is already approved — proceed directly to Stage 1 execution by rendering the dependency graph and spawning Wave 0 agents. In this exception path, the `Agent` tool (plus `TaskCreate`/`TaskUpdate`/`TaskGet` for status, and `TeamCreate`/`SendMessage` if running in team mode) is permitted — these are how Wave 0 phases are spawned. The "all work → delegate" rule above does NOT apply during in-flight delegation continuation.
 
 ## Team Mode
 


### PR DESCRIPTION
## Summary

- **Loop trace**: User approves plan via ExitPlanMode → `remind_skill_continuation.py` writes `workflow_continuation_needed.json` → stop hook emits `decision: block, reason: "continue"` → model sees orchestrator stub rule ("all work MUST go through /workflow-orchestrator:delegate") → re-invokes delegate → re-enters plan mode → regenerates same plan → loops forever.
- **Root cause**: Three-component interaction — (1) `hooks/PostToolUse/remind_skill_continuation.py` unconditionally signals continuation on ExitPlanMode, (2) `hooks/stop/python_stop_hook.py` emitted a vague `"continue"` reason that didn't disambiguate the next action, (3) `system-prompts/orchestrator_stub.md` rule + lack of entry guard in `commands/delegate.md` caused the synthetic continuation to re-route through delegate.
- **Three-layer fix**:
  - *Layer 1* (`hooks/stop/python_stop_hook.py`): Replace vague `reason: "continue"` with explicit anti-redelegation directive ("PLAN ALREADY APPROVED. Execute Stage 1 NOW… DO NOT call /workflow-orchestrator:delegate. DO NOT call EnterPlanMode…").
  - *Layer 2* (`system-prompts/orchestrator_stub.md`): Add "Exception — continuation after plan approval" section between `## Rule` and `## Team Mode`, telling the model the all-work-→-delegate rule does NOT apply mid-delegation.
  - *Layer 3* (`commands/delegate.md`): Insert "RE-INVOCATION GUARD (READ FIRST)" section immediately after frontmatter, catching the loop at the delegate skill's own entry point.

## Test plan

- [x] `git status -sb` → only the three modified files staged
- [x] `git diff --stat` → Layer 1/2/3 each show as expected
- [x] `uvx ruff format --check hooks/stop/python_stop_hook.py` → pass
- [x] `uvx ruff check --select F,E711,E712,UP006,UP007,UP035,UP037,T201,S hooks/stop/python_stop_hook.py` → pass
- [x] `uvx pyright hooks/stop/python_stop_hook.py` → pass (0 errors)
- [x] Read `commands/delegate.md` lines 1-30 → guard is FIRST content after frontmatter
- [x] Read `system-prompts/orchestrator_stub.md` → Exception section present, after `## Rule`, before `## Team Mode`
- [x] Grep `hooks/stop/python_stop_hook.py` for `"reason": "continue"` → no match
- [ ] Manual reproduction: requires a downstream session in a different repo (e.g. `~/dev/agentmem`) after reinstalling the plugin — cannot be reproduced inside the session that authored the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)