### PR TITLE
feat: skip plan mode for fully-specified sequential tasks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "workflow-orchestrator",
       "source": "./",
       "description": "Delegation system with workflow orchestration, specialized agents, and parallel execution for Claude Code",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "author": {
         "name": "Nadav Barkai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-orchestrator",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Delegation system with workflow orchestration, specialized agents, and parallel execution for Claude Code",
   "author": {
     "name": "Nadav Barkai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.2] - 2026-04-12
+
+### Added
+
+- **Skip plan mode for fully-specified sequential tasks.** New routing step (Step 3: Fully-Specified Task Detection) in `commands/delegate.md`. When the user provides explicit ordered steps with no ambiguities or design decisions, the orchestrator routes to direct sequential execution instead of entering plan mode unnecessarily. Detects numbered steps, imperative chains, and explicit signals like "just do it" or "no plan needed".
+
 ## [2.0.1] - 2026-04-12
 
 ### Fixed

--- a/commands/delegate.md
+++ b/commands/delegate.md
@@ -22,7 +22,7 @@ Multi-step workflow orchestration for Claude Code. Main agent enters plan mode (
 
 ## ROUTING (CHECK FIRST - MANDATORY)
 
-**Three-step routing check. MUST follow this order:**
+**Four-step routing check. MUST follow this order:**
 
 ### Step 1: Write Detection
 
@@ -36,12 +36,26 @@ Multi-step workflow orchestration for Claude Code. Main agent enters plan mode (
 
 **Breadth keywords:** review, analyze, summarize, scan + quantifiers like "all", "each", "files in", or explicit counts
 
-### Step 3: Route Decision
+### Step 3: Fully-Specified Task Detection
+
+**Pattern:** The user provided explicit, ordered steps with no ambiguities or design decisions needed. Every step is directly actionable without decomposition.
+
+**Indicators (ANY of these):**
+- Numbered or ordered steps in the request ("1. do X, 2. do Y, 3. do Z")
+- Imperative sequential chain ("do X, then Y, then Z" where each step is concrete)
+- Explicit skip-planning signals: "just do it", "no plan needed", "skip planning", "don't plan"
+- All steps map trivially to tool calls (edit file, run command, commit, push, merge, tag, release)
+- Zero ambiguity: no "should we", "which approach", "evaluate options", "design"
+
+**If fully-specified -> DIRECT SEQUENTIAL EXECUTION** (skip plan mode). Spawn one agent per step or batch related steps into a single agent. No `EnterPlanMode`, no `TaskCreate` during planning.
+
+### Step 4: Route Decision
 
 | Pattern | Route | Example |
 |---------|-------|---------|
 | Breadth + Write (same op x many items, with output) | **DIRECT EXECUTION** (skip plan mode) | "review 16 files, create reports" |
-| Multi-phase workflow (create -> test -> deploy) | plan mode (EnterPlanMode) | "create calculator with tests and verify" |
+| Fully-specified sequential task (all steps explicit) | **DIRECT SEQUENTIAL EXECUTION** (skip plan mode) | "bump version, commit, push, merge, tag, release" |
+| Multi-phase workflow (needs design/decomposition) | plan mode (EnterPlanMode) | "create calculator with tests and verify" |
 | Read-only breadth (no write indicators) | Spawn parallel Explore agents or codebase-context-analyzer | "explore code in X", "summarize files in X" |
 | Single simple task | general-purpose agent | "fix this bug" |
 


### PR DESCRIPTION
## Summary

- Adds **Step 3: Fully-Specified Task Detection** to the routing table in `commands/delegate.md`
- When the user provides explicit, ordered steps with no ambiguities, the orchestrator routes to **direct sequential execution** instead of entering plan mode unnecessarily
- The route decision table becomes a 4-step check (was 3-step), with the new step inserted before the final route decision

## Problem

The orchestrator entered plan mode for every multi-step task, even trivially specified ones like "bump version, commit, push, merge, tag, release." The user had to reject the plan and say "just do it." (#43)

## Detection Indicators

- Numbered/ordered steps in the request
- Imperative sequential chains with concrete steps
- Explicit signals: "just do it", "no plan needed", "skip planning"
- All steps map trivially to tool calls
- Zero ambiguity markers (no "should we", "which approach", "evaluate")

## Test plan

- [ ] Invoke `/workflow-orchestrator:delegate bump version to X, commit, push, merge` — should skip plan mode
- [ ] Invoke `/workflow-orchestrator:delegate create a calculator with tests and verify` — should still enter plan mode (needs decomposition)
- [ ] Invoke `/workflow-orchestrator:delegate just do it: edit file X, commit, push` — should detect "just do it" signal and skip plan mode

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)