### PR TITLE
fix: use cp -rP to preserve symlinks in backup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "workflow-orchestrator",
       "source": "./",
       "description": "Delegation system with workflow orchestration, specialized agents, and parallel execution for Claude Code",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "author": {
         "name": "Nadav Barkai"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workflow-orchestrator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Delegation system with workflow orchestration, specialized agents, and parallel execution for Claude Code",
   "author": {
     "name": "Nadav Barkai"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.1] - 2026-05-04
+
+### Fixed
+- **`install.sh`: use `cp -rP` to preserve symlinks in backup.** Switched from `cp -r` to `cp -rP` so symbolic links inside the Claude directory are copied as symlinks rather than dereferenced, preventing backups from breaking links that point outside the directory.
+
 ## [2.1.0] - 2026-04-26
 
 ### BREAKING CHANGES

--- a/install.sh
+++ b/install.sh
@@ -193,7 +193,7 @@ backup_existing_installation() {
     print_info "Existing installation found at $claude_dir"
     print_info "Creating backup at: $backup_name"
 
-    if cp -r "$claude_dir" "$backup_name"; then
+    if cp -rP "$claude_dir" "$backup_name"; then
         print_success "Backup created successfully: $backup_name"
         # Set global variable for trap handler restore operations
         BACKUP_PATH="$backup_name"


### PR DESCRIPTION
Switch from cp -r to cp -rP so that symbolic links inside the Claude directory are copied as symlinks rather than dereferenced, preventing the backup from breaking links that point outside the directory.