### PR TITLE
feat: strengthen delegation enforcement via three-layer reinforcement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "madrox",
       "description": "MCP server that orchestrates multiple Claude CLI instances as parallel workers with a real-time dashboard",
-      "version": "1.7.5",
+      "version": "1.8.0",
       "source": {
         "source": "github",
         "repo": "barkain/madrox"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Delegation Policy (Soft Enforcement)
 
-The framework nudges via stderr when the main agent uses work-doing tools (`Bash`, `Edit`, `Write`, `Glob`, `Grep`, `MultiEdit`, `NotebookEdit`) directly. **Nudges never block.** They escalate by per-turn violation count: silent → imperative STOP → imperative STOP (2nd call phrasing) → strong reminder explaining what's being lost. The counter resets each turn and zeros when `/workflow-orchestrator:delegate` runs. `Read` is not tracked — direct user-requested file reads are allowed.
+The framework reinforces delegation via three layers: (1) a `BLOCKING REQUIREMENT` stub injected at session start, (2) a per-turn reminder emitted by UserPromptSubmit (treated as user speech), and (3) structured `additionalContext` nudges from PreToolUse when work tools (`Bash`, `Edit`, `Write`, `Glob`, `Grep`, `MultiEdit`, `NotebookEdit`) are called directly. **Nudges never block.** They escalate by per-turn violation count. The counter resets each turn and zeros when `/workflow-orchestrator:delegate` runs. `Read` is not tracked.
 
 The expected path for any multi-step or work-shaped request is:
 
@@ -65,11 +65,11 @@ In plugin mode, all commands and agent names use the `workflow-orchestrator:` pr
 
 ### Execution Flow
 
-**Token overhead:** Conditional injection (stub ~200 tokens on startup, full ~7.5K tokens on first delegation, optional token-efficient guide ~1.9K) + per-agent delegation (~350 tokens)
+**Token overhead:** Conditional injection (stub ~220 tokens on startup + ~14 tokens/turn reminder, full ~7.5K tokens on first delegation, optional token-efficient guide ~1.9K) + per-agent delegation (~350 tokens)
 
 ```
 User prompt
-  → UserPromptSubmit hook (clear state, record turn timestamp, clear team state)
+  → UserPromptSubmit hook (clear state, record turn timestamp, clear team state, emit delegation reminder)
   → SessionStart hooks (inject stub orchestrator + output style + token efficiency)
     [Stub version provides just enough system direction, avoiding unnecessary tokens]
   → Task detection: if multi-step connectors found, enters native plan mode (EnterPlanMode)
@@ -98,9 +98,9 @@ User prompt
 
 | Event | Scripts | Purpose |
 |-------|---------|---------|
-| **PreToolUse** (`*`, `Bash`) | `validate_task_graph_compliance.py` (advisory), `require_delegation.py` (adaptive nudge), `token_rewrite_hook.py` (Bash only) | Hint on out-of-order Agent/Task spawns; emit per-turn escalating delegation nudge (silent → strong); rewrite Bash for token-efficient output |
+| **PreToolUse** (`*`, `Bash`) | `validate_task_graph_compliance.py` (advisory), `require_delegation.py` (adaptive nudge + structured output), `token_rewrite_hook.py` (Bash only) | Hint on out-of-order Agent/Task spawns; emit per-turn escalating delegation nudge via stderr + `additionalContext`; rewrite Bash for token-efficient output |
 | **PostToolUse** | `python_posttooluse_hook.py` (Edit/Write/MultiEdit, **blocking**), `remind_skill_continuation.py` (ExitPlanMode\|Skill\|SlashCommand), `validate_task_graph_depth.py` (advisory) + `remind_todo_after_task.py` (Agent/Task) | Python validation (Ruff, Pyright, security — only hard-blocking hook); workflow continuation + zero violations counter on `/workflow-orchestrator:delegate`; depth hint; task reminders |
-| **UserPromptSubmit** | `clear-delegation-sessions.py` | Reset per-turn state (timestamp, violations counter), clear team state, rotate logs |
+| **UserPromptSubmit** | `clear-delegation-sessions.py` | Reset per-turn state, clear team state, rotate logs, emit delegation reminder (treated as user speech) |
 | **SessionStart** (`startup\|resume\|clear\|compact`) | `inject_all.py` | Consolidated injection (orchestrator stub + token efficiency). Output style is loaded natively from plugin.json's `outputStyles` field |
 | **SubagentStop** (`*`) | `remind_todo_update.py` (async), `trigger_verification.py` | Remind to update tasks, suggest verification |
 | **Stop** | `python_stop_hook.py` | Turn duration, workflow continuation, quality analysis |
@@ -109,7 +109,7 @@ Hook config source of truth: `hooks/plugin-hooks.json` (not settings.json). All 
 
 ### Soft Enforcement (Adaptive Nudges)
 
-There is no allowlist. `require_delegation.py` tracks per-turn direct work-tool calls and writes a stderr message that escalates by count:
+Three reinforcement layers: (1) `BLOCKING REQUIREMENT` stub at session start, (2) per-turn reminder from UserPromptSubmit (~14 tokens, treated as user speech), (3) `require_delegation.py` emits escalating nudges via both stderr and structured `additionalContext` on violations:
 
 | Violations | Message | Tokens |
 |---|---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Delegation Policy (Soft Enforcement)
 
-The framework reinforces delegation via three layers: (1) a `BLOCKING REQUIREMENT` stub injected at session start, (2) a per-turn reminder emitted by UserPromptSubmit (treated as user speech), and (3) structured `additionalContext` nudges from PreToolUse when work tools (`Bash`, `Edit`, `Write`, `Glob`, `Grep`, `MultiEdit`, `NotebookEdit`) are called directly. **Nudges never block.** They escalate by per-turn violation count. The counter resets each turn and zeros when `/workflow-orchestrator:delegate` runs. `Read` is not tracked.
+The framework reinforces delegation via three layers: (1) a `MANDATORY` stub injected at session start, (2) a per-turn reminder emitted by UserPromptSubmit (treated as user speech), and (3) structured `additionalContext` nudges from PreToolUse when work tools (`Bash`, `Edit`, `Write`, `Glob`, `Grep`, `MultiEdit`, `NotebookEdit`) are called directly. **Nudges never block.** They escalate by per-turn violation count. The counter resets each turn and zeros when `/workflow-orchestrator:delegate` runs. `Read` is not tracked.
 
 The expected path for any multi-step or work-shaped request is:
 
@@ -109,7 +109,7 @@ Hook config source of truth: `hooks/plugin-hooks.json` (not settings.json). All 
 
 ### Soft Enforcement (Adaptive Nudges)
 
-Three reinforcement layers: (1) `BLOCKING REQUIREMENT` stub at session start, (2) per-turn reminder from UserPromptSubmit (~14 tokens, treated as user speech), (3) `require_delegation.py` emits escalating nudges via both stderr and structured `additionalContext` on violations:
+Three reinforcement layers: (1) `MANDATORY` stub at session start, (2) per-turn reminder from UserPromptSubmit (~14 tokens, treated as user speech), (3) `require_delegation.py` emits escalating nudges via both stderr and structured `additionalContext` on violations:
 
 | Violations | Message | Tokens |
 |---|---|---|

--- a/hooks/PreToolUse/require_delegation.py
+++ b/hooks/PreToolUse/require_delegation.py
@@ -142,6 +142,13 @@ def main() -> int:
     msg = message_for(count)
     if msg:
         logger.warning("%s", msg)
+        output = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "additionalContext": msg,
+            }
+        }
+        sys.stdout.write(json.dumps(output))
 
     return 0
 

--- a/hooks/UserPromptSubmit/clear-delegation-sessions.py
+++ b/hooks/UserPromptSubmit/clear-delegation-sessions.py
@@ -13,10 +13,23 @@ Resets per-turn state at the start of each user prompt:
 This Python version works on Windows, macOS, and Linux.
 """
 
+import io
+import logging
 import os
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
+
+# Force UTF-8 output on Windows
+if sys.platform == "win32":
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
+
+logger = logging.getLogger("delegation_reminder")
+logger.setLevel(logging.WARNING)
+_handler = logging.StreamHandler(sys.stderr)
+_handler.setFormatter(logging.Formatter("%(message)s"))
+logger.addHandler(_handler)
 
 MAX_LOG_SIZE = 1048576  # 1MB
 MAX_ROTATIONS = 5
@@ -96,6 +109,20 @@ def cleanup_old_validations(validation_dir: Path) -> None:
             pass
 
 
+def is_subagent() -> bool:
+    """True if running inside a subagent."""
+    return bool(
+        os.environ.get("CLAUDE_PARENT_SESSION_ID") or os.environ.get("CLAUDE_AGENT_ID")
+    )
+
+
+def emit_delegation_reminder() -> None:
+    """One-line reinforcement. Appears as <user-prompt-submit-hook> — treated as user speech."""
+    logger.warning(
+        "Use /workflow-orchestrator:delegate for all work — never call work tools directly."
+    )
+
+
 def main() -> int:
     """Main entry point."""
     state_dir = get_state_dir()
@@ -116,6 +143,9 @@ def main() -> int:
 
     rotate_log(state_dir / "validation" / "gate_invocations.log")
     cleanup_old_validations(state_dir / "validation")
+
+    if not is_subagent():
+        emit_delegation_reminder()
 
     return 0
 

--- a/system-prompts/orchestrator_stub.md
+++ b/system-prompts/orchestrator_stub.md
@@ -1,6 +1,6 @@
 # Workflow Orchestrator
 
-BLOCKING REQUIREMENT: Before calling Bash, Edit, Write, Glob, Grep, MultiEdit, or NotebookEdit, you MUST run `/workflow-orchestrator:delegate <task>` first. No exceptions. This includes investigation — do not Read/Bash to explore before deciding; delegate the exploration itself.
+MANDATORY: You MUST run `/workflow-orchestrator:delegate <task>` before calling Bash, Edit, Write, Glob, Grep, MultiEdit, or NotebookEdit. No exceptions. This includes investigation — do not Read/Bash to explore before deciding; delegate the exploration itself.
 
 You are an orchestrator, not an executor. Permitted direct tools: Tasks API, AskUserQuestion, Read (only a single file the user explicitly asked to display), and `/workflow-orchestrator:delegate`.
 

--- a/system-prompts/orchestrator_stub.md
+++ b/system-prompts/orchestrator_stub.md
@@ -1,50 +1,19 @@
-# Workflow Orchestrator (Routing Stub)
+# Workflow Orchestrator
 
-## Rule
+BLOCKING REQUIREMENT: Before calling Bash, Edit, Write, Glob, Grep, MultiEdit, or NotebookEdit, you MUST run `/workflow-orchestrator:delegate <task>` first. No exceptions. This includes investigation — do not Read/Bash to explore before deciding; delegate the exploration itself.
 
-Any user request that requires work — writing code, running tools, multi-step tasks, breadth tasks (same operation across many items), or anything beyond a direct question — **MUST** be handled via:
+You are an orchestrator, not an executor. Permitted direct tools: Tasks API, AskUserQuestion, Read (only a single file the user explicitly asked to display), and `/workflow-orchestrator:delegate`.
 
-```
-/workflow-orchestrator:delegate <full task description>
-```
+## Continuation after plan approval
 
-The main agent does not execute work tools directly. Use only: Tasks API, AskUserQuestion, and `/workflow-orchestrator:delegate`. The delegate command loads the full orchestrator (planning, agent assignment, execution waves) on demand.
+If you received "PLAN ALREADY APPROVED" or "continuing to STAGE 1" from the Stop hook: do NOT re-invoke `/delegate` or `EnterPlanMode`. Proceed to Stage 1 — render the dependency graph, spawn Wave 0 agents. Agent, TaskCreate/TaskUpdate/TaskGet, TeamCreate/SendMessage are permitted in this path.
 
-## Exception — continuation after plan approval
+Plan missing after context-clear? Read `.claude/state/approved_execution_plan.json`. If gone, ask the user to re-run `/workflow-orchestrator:delegate`.
 
-If you received a "PLAN ALREADY APPROVED" or "continuing to STAGE 1" continuation message from the Stop hook, **do NOT re-invoke `/workflow-orchestrator:delegate`** and **do NOT call `EnterPlanMode`** again. The orchestrator is already loaded and the plan is already approved — proceed directly to Stage 1 execution by rendering the dependency graph and spawning Wave 0 agents. In this exception path, the `Agent` tool (plus `TaskCreate`/`TaskUpdate`/`TaskGet` for status, and `TeamCreate`/`SendMessage` if running in team mode) is permitted — these are how Wave 0 phases are spawned. The "all work → delegate" rule above does NOT apply during in-flight delegation continuation.
+## Team mode
 
-**Fallback if plan is missing from context** (e.g., after context-clear): if the continuation message says "PLAN ALREADY APPROVED" but you cannot find the plan in your context:
-1. Read `.claude/state/approved_execution_plan.json` to recover the plan, then proceed to Stage 1.
-2. If that file is also missing, inform the user the plan was lost and ask them to re-run `/workflow-orchestrator:delegate <original task>`. Do NOT silently re-invoke `/workflow-orchestrator:delegate` yourself.
-
-## What counts as "work"
-
-ANY of these = delegate:
-- Reading, searching, editing, or writing files (Read, Grep, Glob, Edit, Write, MultiEdit, NotebookEdit)
-- Running shell commands (Bash) for anything beyond a single trivial status check
-- Investigating the codebase to answer a question that requires file access → delegate
-- Multi-step tasks, even if each step looks simple in isolation
-
-**Exemption:** a single `Read` of an exact file path the user explicitly asked to display (e.g., "show me file X", "read foo.py") may be done directly — no delegation needed.
-
-## What you MUST NOT do
-
-- Do NOT use Read to investigate before deciding — delegate the investigation
-- Do NOT run `grep`/`find`/`ls` via Bash — delegate
-- Do NOT make "just a small edit" directly — delegate
-- Do NOT chain 2+ tool calls to accomplish one user request — delegate
-
-If you catch yourself about to call Bash/Edit/Write/Read/Glob/Grep/MultiEdit/NotebookEdit, STOP and invoke `/workflow-orchestrator:delegate <task>` instead.
-
-## Team Mode
-
-If `TeamCreate` is in your available tools, agent teams are enabled. When you run `/workflow-orchestrator:delegate`, default to team mode (`TeamCreate` + `Agent(team_name=...)`) for multi-agent work. If `TeamCreate` is not available, the delegate flow falls back to parallel subagents automatically.
-
-You do not need to check env vars or run Bash to detect this — tool availability is the signal.
+`TeamCreate` in available tools → team mode. Not available → parallel subagents. No env checks needed.
 
 ## Pure Q&A
 
-If the user is only asking a question (no work to perform), answer directly.
-- Single file the user asked to read → use `Read` directly.
-- Multi-file investigation or codebase questions → use `/workflow-orchestrator:delegate <question>`.
+Questions with no work → answer directly. Single file user asked to read → `Read` directly. Multi-file investigation → delegate.

--- a/tests/test_require_delegation.py
+++ b/tests/test_require_delegation.py
@@ -76,14 +76,18 @@ class TestViolationSet:
         ["Bash", "Edit", "Write", "Glob", "Grep", "MultiEdit", "NotebookEdit"],
     )
     def test_work_tools_count_as_violations(self, tmp_path: Path, tool: str) -> None:
-        _, stderr, _ = _run(_input(tool), tmp_path)
+        stdout, stderr, _ = _run(_input(tool), tmp_path)
         assert "delegate" in stderr.lower()  # noqa: S101
+        # Structured output also emitted
+        parsed = json.loads(stdout)
+        assert "delegate" in parsed["hookSpecificOutput"]["additionalContext"].lower()  # noqa: S101
 
     def test_read_is_silent(self, tmp_path: Path) -> None:
         """Read is exempt from delegation nudges (not in WORK_TOOLS)."""
-        _, stderr, rc = _run(_input("Read"), tmp_path)
+        stdout, stderr, rc = _run(_input("Read"), tmp_path)
         assert rc == 0  # noqa: S101
         assert stderr == ""  # noqa: S101
+        assert stdout == ""  # noqa: S101
 
     @pytest.mark.parametrize(
         "tool",
@@ -105,9 +109,10 @@ class TestViolationSet:
         ],
     )
     def test_non_work_tools_silent(self, tmp_path: Path, tool: str) -> None:
-        _, stderr, rc = _run(_input(tool), tmp_path)
+        stdout, stderr, rc = _run(_input(tool), tmp_path)
         assert rc == 0  # noqa: S101
         assert stderr == ""  # noqa: S101
+        assert stdout == ""  # noqa: S101
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Stub rewrite**: Opens with `BLOCKING REQUIREMENT` (proven constraint pattern from Claude Code's own system prompt). Cut from ~450 words to ~167 words — shorter but stronger.
- **Per-turn reminder**: `UserPromptSubmit` hook now emits a one-line delegation reminder to stderr, which Claude Code wraps as `<user-prompt-submit-hook>` and treats as user speech. ~14 tokens/turn, subagent-safe.
- **Structured output**: `PreToolUse` violations now emit `additionalContext` via stdout JSON in addition to stderr. Surfaces the nudge in conversation context, not just as a side-channel log. Zero cost when compliant.

## Motivation
Since moving from hard-blocking hooks (v2.0.0) to soft stderr nudges, Claude frequently "forgets" to delegate — the ~200-token stub injected at session start gets buried as conversation grows, and stderr nudges after the fact aren't enough to prevent the first violation.

## Test plan
- [x] All 37 existing tests pass (updated to verify structured JSON output)
- [x] Ruff + Pyright clean
- [ ] Manual: start a new session, give a multi-step task, verify Claude delegates instead of executing directly
- [ ] Manual: verify subagents don't see the per-turn reminder (no double-delegation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)