### PR TITLE
chore: bump madrox marketplace version to 1.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "madrox",
       "description": "MCP server that orchestrates multiple Claude CLI instances as parallel workers with a real-time dashboard",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "source": {
         "source": "github",
         "repo": "barkain/madrox"


### PR DESCRIPTION
Bumps the `madrox` entry in `marketplace.json` from 1.8.0 → 1.8.1 to track the [madrox v1.8.1 release](https://github.com/barkain/madrox/releases/tag/v1.8.1).

## What's in madrox 1.8.1
- **Codex backend failures are no longer silent** (#28) — backend errors now surface as `status: "failed"` with the error message instead of an empty `completed` no-op.
- **Removed the static model allowlist** (#28) — model strings are forwarded to the underlying CLI/backend as-is.

## Scope
- Only the `madrox` marketplace entry is bumped.
- The repo's `plugin.json` (version 2.1.0) belongs to the **workflow-orchestrator** plugin, a separate product — intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)