### PR TITLE
chore: bump madrox marketplace version to 1.8.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "madrox",
       "description": "MCP server that orchestrates multiple Claude CLI instances as parallel workers with a real-time dashboard",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "source": {
         "source": "github",
         "repo": "barkain/madrox"


### PR DESCRIPTION
Points the `barkain-plugins` marketplace at **madrox v1.8.2**.

madrox 1.8.2 fixes the severe subprocess leak from orphaned orchestrator stacks (barkain/madrox#30) — every plugin session was leaking its backend, `multiprocessing.Manager` daemon, and frontend to `launchd`, accumulating into the hundreds and exhausting RAM. On first launch after updating, the plugin also reaps orphans left behind by 1.8.1.

- madrox release: https://github.com/barkain/madrox/releases/tag/v1.8.2
- Only change here: `madrox` plugin `version` `1.8.1` → `1.8.2` in `.claude-plugin/marketplace.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)