### PR TITLE
chore: bump madrox marketplace version to 1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "madrox",
       "description": "MCP server that orchestrates multiple Claude CLI instances as parallel workers with a real-time dashboard",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "source": {
         "source": "github",
         "repo": "barkain/madrox"


### PR DESCRIPTION
Bumps the `madrox` entry in `.claude-plugin/marketplace.json` from `1.8.2` to `1.9.0`, matching the 1.9.0 release in [barkain/madrox](https://github.com/barkain/madrox) (new Grok Build harness + harness registry, plus a batch of spawn/config fixes).

Without this the marketplace keeps advertising 1.8.2, so `/plugin update madrox` finds nothing to do even once the code is on main.

### ⚠️ Merge order

**Merge this after https://github.com/barkain/madrox/pull/32.**

The `madrox` entry has no `ref`, so it installs from that repo's default branch. Bumping here while `barkain/madrox@main` is still at 1.8.2 would advertise a version the source does not actually contain — an upgrade would install old code under a new version label.

### Scope

One line. The `workflow-orchestrator` entry's own version is untouched.