### PR TITLE
chore: bump madrox marketplace version to 1.9.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     {
       "name": "madrox",
       "description": "MCP server that orchestrates multiple Claude CLI instances as parallel workers with a real-time dashboard",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "source": {
         "source": "github",
         "repo": "barkain/madrox"


### PR DESCRIPTION
Bumps the `madrox` entry from `1.9.0` to `1.9.1`, matching the patch release in [barkain/madrox](https://github.com/barkain/madrox).

Without this the marketplace keeps advertising 1.9.0 and `/plugin update madrox` finds nothing to do.

### ⚠️ Merge last

Merge **after** both:
- https://github.com/barkain/madrox/pull/33 — session startup cost (dashboard on demand, `uv sync` no longer blocks the handshake, spawning survives a deleted cwd)
- https://github.com/barkain/madrox/pull/34 — Grok `-m` flag and no pinned model ids (carries the 1.9.1 version bump)

The `madrox` entry has no `ref`, so it installs from that repo's default branch. Bumping here first would advertise a version `main` does not yet contain — an "upgrade" that installs older code under a newer label and then reports itself up to date.

### Scope

One line. The `workflow-orchestrator` entry's own version is untouched.